### PR TITLE
Fix missing SupportColumnComplete error

### DIFF
--- a/src/Intra/Service/Support/SupportModel.php
+++ b/src/Intra/Service/Support/SupportModel.php
@@ -111,7 +111,7 @@ class SupportModel extends BaseModel
             throw new \Exception('정렬 컬럼지정이 되어있지 않습니다.');
         }
         if (count($complete_columns) == 0) {
-            throw new \Exception('승인가능한 컬럼지정이 되어있지 않습니다.');
+            return [];
         }
 
         $table = self::getTableName($target);
@@ -149,7 +149,7 @@ class SupportModel extends BaseModel
             throw new \Exception('정렬 컬럼지정이 되어있지 않습니다.');
         }
         if (count($accept_columns) == 0) {
-            return null;
+            return [];
         }
 
         $table = self::getTableName($target);


### PR DESCRIPTION
Support페이지에 SupportColumnComplete 칼럼이 없을때 발생하는 오류 수정했습니다.
마찬가지로 SupportColumnAcceptUser가 없을때 null대신 배열을 리턴하여 오류를 제거했습니다.