### PR TITLE
Add a column for the email in the support vpn menu.

### DIFF
--- a/assets/views/support/index.twig
+++ b/assets/views/support/index.twig
@@ -353,6 +353,7 @@
           {% if column.class_name == 'SupportColumnReadonly' %}
           {% elseif column.class_name == 'SupportColumnByValueCallback' %}
           {% elseif column.class_name == 'SupportColumnRegisterUser' %}
+          {% elseif column.class_name == 'SupportColumnRegisterEmail' %}
           {% elseif column.class_name == 'SupportColumnComplete' %}
           {% elseif column.class_name == 'SupportColumnCompleteUser' %}
           {% elseif column.class_name == 'SupportColumnCompleteDatetime' %}

--- a/db/migrations/20170802094609_add_support_vpn_email_column.php
+++ b/db/migrations/20170802094609_add_support_vpn_email_column.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+class AddSupportVpnEmailColumn extends AbstractMigration
+{
+    public function change()
+    {
+        $this->table('support_vpn')
+            ->addColumn('email', 'string', ['length' => 100, 'comment' => '신청자 email'])
+            ->save();
+    }
+}

--- a/src/Intra/Service/Support/Column/SupportColumnRegisterEmail.php
+++ b/src/Intra/Service/Support/Column/SupportColumnRegisterEmail.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Intra\Service\Support\Column;
+
+class SupportColumnRegisterEmail extends SupportColumn
+{
+}

--- a/src/Intra/Service/Support/SupportDto.php
+++ b/src/Intra/Service/Support/SupportDto.php
@@ -11,11 +11,13 @@ use Intra\Service\Support\Column\SupportColumnDate;
 use Intra\Service\Support\Column\SupportColumnDatetime;
 use Intra\Service\Support\Column\SupportColumnMoney;
 use Intra\Service\Support\Column\SupportColumnMutual;
+use Intra\Service\Support\Column\SupportColumnRegisterEmail;
 use Intra\Service\Support\Column\SupportColumnRegisterUser;
 use Intra\Service\Support\Column\SupportColumnTeam;
 use Intra\Service\Support\Column\SupportColumnText;
 use Intra\Service\Support\Column\SupportColumnTextDetail;
 use Intra\Service\Support\Column\SupportColumnWorker;
+use Intra\Service\User\UserJoinService;
 use Symfony\Component\HttpFoundation\Request;
 
 class SupportDto
@@ -67,6 +69,10 @@ class SupportDto
             } elseif ($column instanceof SupportColumnRegisterUser) {
                 $key = $column->key;
                 $value = $uid;
+                $dto->dict[$key] = $value;
+            } elseif ($column instanceof SupportColumnRegisterEmail) {
+                $key = $column->key;
+                $value = UserJoinService::getEmailByUidSafe($uid);
                 $dto->dict[$key] = $value;
             }
         }

--- a/src/Intra/Service/Support/SupportPolicy.php
+++ b/src/Intra/Service/Support/SupportPolicy.php
@@ -17,6 +17,7 @@ use Intra\Service\Support\Column\SupportColumnFile;
 use Intra\Service\Support\Column\SupportColumnMoney;
 use Intra\Service\Support\Column\SupportColumnMutual;
 use Intra\Service\Support\Column\SupportColumnReadonly;
+use Intra\Service\Support\Column\SupportColumnRegisterEmail;
 use Intra\Service\Support\Column\SupportColumnRegisterUser;
 use Intra\Service\Support\Column\SupportColumnTeam;
 use Intra\Service\Support\Column\SupportColumnText;
@@ -422,6 +423,7 @@ class SupportPolicy
                 '일련번호2' => new SupportColumnReadonly('id'),
                 '요청일' => (new SupportColumnReadonly('reg_date'))->setOrderingColumn(),
                 '요청자' => new SupportColumnRegisterUser('uid'),
+                '요청자 메일' => new SupportColumnRegisterEmail('email'),
                 '부서' => new SupportColumnByValueCallback('team', $get_team_by_uid),
                 '승인' => new SupportColumnAccept('is_accepted'),
                 '승인자' => new SupportColumnAcceptUser('accept_uid', 'is_accepted'),


### PR DESCRIPTION
* Issue: https://app.asana.com/0/13354122204765/355077597957534/f

I added new SupportColumn class, `SupportColumnRegisterEmail`.
It is almost same with `SupportColumnRegisterUser`, but displays user's email.

(I'm not satisfied this codes, however I think the thing is to maintain unified style at this time..)