### PR TITLE
Fix 'download excel by this year' to get yearly data

### DIFF
--- a/src/Intra/Controller/SupportController.php
+++ b/src/Intra/Controller/SupportController.php
@@ -184,7 +184,7 @@ class SupportController implements ControllerProviderInterface
         $yearmonth = $request->get('yearmonth');
         if ($type == 'year') {
             $date = date_create($yearmonth . '-01');
-            $begin_datetime = (clone $date)->modify("first day of this year");
+            $begin_datetime = (clone $date)->modify("first day of january this year");
             $end_datetime = (clone $begin_datetime)->modify("first day of next year");
         } elseif ($type == 'yearmonth') {
             $begin_datetime = date_create($yearmonth . '-01');
@@ -207,7 +207,7 @@ class SupportController implements ControllerProviderInterface
         foreach ($support_view_dtos as $support_view_dto) {
             $csv_row = [];
             foreach ($columns as $column_name => $column) {
-                $csv_row[$column_name] = $support_view_dto->display_dict[$column->key];
+                $csv_row[$column_name] = $support_view_dto->display_dict[$column->key] ?? '';
             }
             $csv_row = $this->excelPostworkBody($csv_row, $target);
             $csvs[] = $csv_row;


### PR DESCRIPTION
**이슈**
엑셀 다운로드 기능이 연간데이터를 다운로드할때 월간데이터를 다운로드하는 문제

**원인**
`modify("first day of this year")`가 적절하게 연초 1월 1일 날짜를 가져오지 못합니다. 원래 동작이 이랬던것인지 변경된건지 알 수 없습니다. 아마도 최초부터 있던문제인데 테스트가 적절히 되지 않은걸로 보입니다만..

**테스트**
로컬에서 테스트 완료했습니다. 도중에 컬럼이 비어있으면 예외가 발생하는 문제를 발견하여 수정했습니다.

관련이슈: https://app.asana.com/0/235684600038401/405254860869765