### PR TITLE
Some bug fixs

### DIFF
--- a/assets/js/components/HolidayAdjust/HolidayAdjust.jsx
+++ b/assets/js/components/HolidayAdjust/HolidayAdjust.jsx
@@ -93,6 +93,11 @@ class HolidayAdjust extends React.Component {
       return;
     }
 
+    if(!this.state.managerUid) {
+      alert('결제자를 선택하셔야 합니다.');
+      return;
+    }
+
     const data = {
       uid: this.state.uid,
       diffYear: this.state.diffYear,

--- a/db/migrations/20170822065552_fix_holiday_adjusts_diff_type.php
+++ b/db/migrations/20170822065552_fix_holiday_adjusts_diff_type.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+class FixHolidayAdjustsDiffType extends AbstractMigration
+{
+    public function change()
+    {
+        $this->table('holiday_adjusts')
+            ->changeColumn('diff', 'float')
+            ->save();
+    }
+}

--- a/docs/deployer/deploy.php
+++ b/docs/deployer/deploy.php
@@ -4,7 +4,6 @@ namespace Deployer;
 require_once 'recipe/common.php';
 require_once 'vendor/deployer/recipes/slack.php';
 
-require_once __DIR__ . '/task/envTask.php';
 require_once __DIR__ . '/task/slackTask.php';
 require_once __DIR__ . '/task/vaultTask.php';
 

--- a/src/Intra/Service/Holiday/UserHolidayPolicy.php
+++ b/src/Intra/Service/Holiday/UserHolidayPolicy.php
@@ -155,14 +155,14 @@ class UserHolidayPolicy
     public function getModCost($year)
     {
         return HolidayAdjustModel::where('uid', $this->user->uid)
-            ->where('diff_year', '<=', $year)
+            ->where('diff_year', '=', $year)
             ->sum('diff');
     }
 
     public function getModList($year)
     {
         return HolidayAdjustModel::where('uid', $this->user->uid)
-            ->where('diff_year', '<=', $year)
+            ->where('diff_year', '=', $year)
             ->get();
     }
 


### PR DESCRIPTION
### 이슈:
https://app.asana.com/0/235684600038401/412223956602378/f

### 원인과 수정:
- 휴가 조정 기능에 문제가 있었습니다. (Asana에 언급된 것 외에도)
  - 반차 단위 수정이 필요한 경우 소수점 입력 시 제대로 반영이 안됨 | 2ddd4b7
  - 결제자를 지정하지 않고 수정이 가능하고, 에러 발생 | 1012277
  - 수정을 지정한 연도 이후에도 수정 내역이 적용됨 | 2cd8916
- 그외
  - Deployer로 배포 시 이미 삭제된 파일을 참조하면서 에러 발생 | b345cd5

### 확인 방법:
- 근태 관리 > 휴가 조정 (관리자) 메뉴에서
  - 소수점 단위로 수정을 해본다.
  - 결제자를 지정하지 않고 등록해본다.
  - 2017년으로 수정을 등록하고 휴가 메뉴에서 2018년으로 수정된 직원의 휴가 내역을 살펴본다. (관리자 계정으로 휴가 신청 페이지에서 해당 직원을 선택하고 우상단 표에서 '조정 일자'를 확인)
- Deployer로 로컬 상에 배포 명령을 실행해본다.