### PR TITLE
직원 권한 체크 변경

### DIFF
--- a/src/Intra/Service/Auth/ExceptOuter.php
+++ b/src/Intra/Service/Auth/ExceptOuter.php
@@ -1,0 +1,19 @@
+<?php
+namespace Intra\Service\Auth;
+
+use Intra\Service\Auth\Superclass\AuthMultiplexer;
+use Intra\Service\User\UserDto;
+use Intra\Service\User\UserPolicy;
+
+class ExceptOuter extends AuthMultiplexer
+{
+    /**
+     * @param UserDto $user_dto
+     *
+     * @return bool
+     */
+    protected function hasAuth(UserDto $user_dto)
+    {
+        return !(UserPolicy::isStudioD($user_dto) || UserPolicy::isTa($user_dto));
+    }
+}

--- a/src/Intra/Service/Auth/ExceptStudioD.php
+++ b/src/Intra/Service/Auth/ExceptStudioD.php
@@ -1,0 +1,19 @@
+<?php
+namespace Intra\Service\Auth;
+
+use Intra\Service\Auth\Superclass\AuthMultiplexer;
+use Intra\Service\User\UserDto;
+use Intra\Service\User\UserPolicy;
+
+class ExceptStudioD extends AuthMultiplexer
+{
+    /**
+     * @param UserDto $user_dto
+     *
+     * @return bool
+     */
+    protected function hasAuth(UserDto $user_dto)
+    {
+        return !(UserPolicy::isStudioD($user_dto));
+    }
+}

--- a/src/Intra/Service/Menu/Link.php
+++ b/src/Intra/Service/Menu/Link.php
@@ -2,7 +2,7 @@
 
 namespace Intra\Service\Menu;
 
-use Intra\Service\Auth\ExceptTaAuth;
+use Intra\Service\Auth\ExceptOuter;
 use Intra\Service\Auth\Superclass\AuthMultiplexer;
 use Intra\Service\User\UserSession;
 
@@ -29,7 +29,7 @@ class Link
          * @var AuthMultiplexer
          */
         if (is_null($auth_checker)) {
-            $auth_checker = new ExceptTaAuth();
+            $auth_checker = new ExceptOuter();
         }
 
         $this->title = $title;

--- a/src/Intra/Service/Menu/MenuService.php
+++ b/src/Intra/Service/Menu/MenuService.php
@@ -2,6 +2,8 @@
 
 namespace Intra\Service\Menu;
 
+use Intra\Service\Auth\ExceptOuter;
+use Intra\Service\Auth\ExceptStudioD;
 use Intra\Service\Auth\ExceptTaAuth;
 use Intra\Service\Auth\OnlyHolidayEditable;
 use Intra\Service\Auth\OnlyPressManager;
@@ -38,33 +40,33 @@ class MenuService
         if (UserSession::isLogined()) {
             if ($_ENV['domain'] == 'ridi.com') {
                 $left_menu_list = [
-                    new Link('직원찾기', '/users/', new PublicAuth()),
+                    new Link('직원찾기', '/users/', new ExceptStudioD()),
                     new Link('리디 생활 가이드', self::RIDI_GUIDE_URL, null, '_blank'),
-                    new Link('전사 주간 업무 요약', '/weekly/', new ExceptTaAuth(), '_blank'),
-                    new Link('회의실', '/rooms/', new PublicAuth()),
+                    new Link('전사 주간 업무 요약', '/weekly/', new ExceptOuter(), '_blank'),
+                    new Link('회의실', '/rooms/', new ExceptStudioD()),
                     new Link('포커스룸', '/focus/'),
                     '근태관리' => [
-                        new Link('휴가신청', '/holidays/', new PublicAuth()),
+                        new Link('휴가신청', '/holidays/', new ExceptStudioD()),
                         new Link('휴가조정(관리자)', '/holidayadmin/', new OnlyHolidayEditable()),
-                        new Link('얼리파마', '/flextime/', new PublicAuth()),
+                        new Link('얼리파마', '/flextime/', new ExceptStudioD()),
                     ],
                     '지원요청' => [
-                        new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_DEVICE), '/support/' . SupportPolicy::TYPE_DEVICE, new PublicAuth()),
+                        new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_DEVICE), '/support/' . SupportPolicy::TYPE_DEVICE, new ExceptStudioD()),
                         new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_FAMILY_EVENT), '/support/' . SupportPolicy::TYPE_FAMILY_EVENT),
                         new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_BUSINESS_CARD), '/support/' . SupportPolicy::TYPE_BUSINESS_CARD),
-                        new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_DEPOT), '/support/' . SupportPolicy::TYPE_DEPOT, (new ExceptTaAuth())->accept(['hr.ta'])),
+                        new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_DEPOT), '/support/' . SupportPolicy::TYPE_DEPOT, (new ExceptOuter())->accept(['hr.ta'])),
                         new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_GIFT_CARD_PURCHASE), '/support/' . SupportPolicy::TYPE_GIFT_CARD_PURCHASE),
                         new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_TRAINING), '/support/' . SupportPolicy::TYPE_TRAINING),
-                        new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_DINNER), '/support/' . SupportPolicy::TYPE_DINNER, new PublicAuth(), '_blank'),
-                        new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_DELIVERY), '/support/' . SupportPolicy::TYPE_DELIVERY, new PublicAuth(), '_blank'),
-                        new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_PRESENT), '/support/' . SupportPolicy::TYPE_PRESENT, new PublicAuth(), '_blank'),
-                        new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_VPN), '/support/' . SupportPolicy::TYPE_VPN, new PublicAuth()),
+                        new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_DINNER), '/support/' . SupportPolicy::TYPE_DINNER, new ExceptStudioD(), '_blank'),
+                        new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_DELIVERY), '/support/' . SupportPolicy::TYPE_DELIVERY, new ExceptStudioD(), '_blank'),
+                        new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_PRESENT), '/support/' . SupportPolicy::TYPE_PRESENT, new ExceptStudioD(), '_blank'),
+                        new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_VPN), '/support/' . SupportPolicy::TYPE_VPN, new ExceptStudioD()),
                     ],
                     new Link('결제요청', '/payments/', (new ExceptTaAuth())->accept(['hr.ta', 'device.ta3'])),
-                    new Link('비용정산', '/receipts/', new PublicAuth()),
-                    new Link('급여관리', 'http://htms.himgt.net', new ExceptTaAuth(), '_blank'),
+                    new Link('비용정산', '/receipts/', new ExceptStudioD()),
+                    new Link('급여관리', 'http://htms.himgt.net', new ExceptOuter(), '_blank'),
                     new Link('보도자료 관리', '/press/', new OnlyPressManager()),
-                    new Link('조직도', '/organization/chart', new ExceptTaAuth(), '_blank'),
+                    new Link('조직도', '/organization/chart', new ExceptOuter(), '_blank'),
                 ];
             } else {
                 $left_menu_list = [

--- a/src/Intra/Service/User/UserPolicy.php
+++ b/src/Intra/Service/User/UserPolicy.php
@@ -108,6 +108,16 @@ class UserPolicy
         return false;
     }
 
+
+    public static function isStudioD(UserDto $user)
+    {
+        if ($user->email === "studiod@ridi.com") {
+            return true;
+        }
+
+        return false;
+    }
+
     public static function assertRestrictedPath(Request $request)
     {
         $free_to_login_path = [

--- a/src/Intra/Service/User/UserPolicy.php
+++ b/src/Intra/Service/User/UserPolicy.php
@@ -101,6 +101,7 @@ class UserPolicy
         if (strpos($user->email, ".ta") !== false
             || strpos($user->email, ".oa") !== false
             || strpos(strtoupper($user->name), "TA") !== false
+            || strpos(strtoupper($user->name), "(아)") !== false
         ) {
             return true;
         }


### PR DESCRIPTION
### 이슈:
https://app.asana.com/0/235684600038401/421333721417912/f
https://app.asana.com/0/235684600038401/420195612960356/f

### 변경:

1. **studiod 계정 예외처리**
studiod@ridi.com 계정인 경우 결제 요청만 접근할 수 있도록 하기 위해서 기존 접근을 아래처럼 변경했습니다.
- 권한을 PublicAuth(전체 열람 가능)로 지정했던 건 ExceptStuidoD(StudioD제외)로 변경
- 권한을 ExceptTA(TA만 제외)로 지정했던 건 ExceptOuter(TA+StudioD제외)로 변경
- 권한을 지정하지 않은 경우(=default, TA제외)는 ExceptOuter(TA+StudioD제외)로 변경
- 결제 내역 메뉴는 기존처럼 ExceptTA로 놔둠

2. **아르바이트 직원 추가**
이름에 "(아)"가 들어가는 경우는 아르바이트 직원으로 분류합니다.
아르바이트 직원 접근 권한은 기존 TA랑 동일하기 때문에 isTA의 체크 조건에 "(아)" 문자열 포함 여부를 추가하는 것으로 처리했습니다.