### PR TITLE
Fix download holiday delay

### DIFF
--- a/src/Intra/Controller/HolidaysController.php
+++ b/src/Intra/Controller/HolidaysController.php
@@ -238,7 +238,7 @@ class HolidaysController implements ControllerProviderInterface
             $rows[] = $row;
         }
 
-        return new CsvResponse($rows);
+        return new CsvResponse($rows, null, true);
     }
 
     public function downloadRemain(Request $request)

--- a/src/Intra/Model/HolidayModel.php
+++ b/src/Intra/Model/HolidayModel.php
@@ -40,12 +40,22 @@ class HolidayModel
             ];
         } else {
             $where = [
-                'uid' => $user->uid,
+                'holidays.uid' => $user->uid,
                 'hidden' => 0,
                 'date' => sqlBetween($begin, $end),
             ];
         }
-        return $this->db->sqlObjects('select * from holidays where ? order by uid asc, date asc', sqlWhere($where));
+
+        return $this->db->sqlObjects('
+          select *,
+            user.name as uid_name,
+            manager.name as manager_uid_name,
+            keeper.name as keeper_uid_name
+          from holidays
+            LEFT JOIN users user on holidays.uid = user.uid
+            LEFT JOIN users manager on holidays.manager_uid = manager.uid
+            LEFT JOIN users keeper on holidays.keeper_uid = keeper.uid
+          where ? order by holidays.uid asc, date asc', sqlWhere($where));
     }
 
     public function add(UserHolidayDto $holidayRaw)

--- a/src/Intra/Service/Holiday/UserHoliday.php
+++ b/src/Intra/Service/Holiday/UserHoliday.php
@@ -43,8 +43,6 @@ class UserHoliday
         $end = date('Y/m/d', $this->user_holiday_policy->getYearlyEndTimestamp($yearly));
         $holidays = $this->user_holiday_model->getHolidaysByUserYearly($this->user, $begin, $end);
 
-        self::filterHolidays($holidays);
-
         return $holidays;
     }
 
@@ -57,21 +55,7 @@ class UserHoliday
     {
         $holidayRaw = $this->user_holiday_model->get($holidayid, $this->user->uid);
         $holidayRaws = [$holidayRaw];
-        self::filterHolidays($holidayRaws);
         return $holidayRaws[0];
-    }
-
-    /**
-     * @param $holidays
-     */
-    public static function filterHolidays($holidays)
-    {
-        foreach ($holidays as $holiday) {
-            $holiday->personcode = self::getPersonCodeSafe($holiday->uid);
-            $holiday->uid_name = self::getUserNameSafe($holiday->uid);
-            $holiday->manager_uid_name = self::getUserNameSafe($holiday->manager_uid);
-            $holiday->keeper_uid_name = self::getUserNameSafe($holiday->keeper_uid);
-        }
     }
 
     public function edit($holidayid, $key, $value)

--- a/src/Intra/Service/Holiday/UserHolidayStat.php
+++ b/src/Intra/Service/Holiday/UserHolidayStat.php
@@ -16,8 +16,6 @@ class UserHolidayStat
         $end = date(($year) . '/12/31');
         $holidays = $this->user_holiday_model->getHolidaysByUserYearly(null, $begin, $end);
 
-        UserHoliday::filterHolidays($holidays);
-
         return $holidays;
     }
 }


### PR DESCRIPTION
## Description
다량의 휴가데이터(현재 약 2300건)를 다운로드시 모든 열에 대해서 비효율적으로 DB쿼리를 다시 하고있어 request timeout이 발생합니다. 여러번의 쿼리를 호출하는대신 테이블을 Join하도록 수정했습니다.

이 과정에서 gnfdb의 sqlJoin 함수를 사용하려고 했으나 중복된 Join으로 인해 발생하는 동일한 테이블 명에 대한 alias생성이 되지 않는듯(?)하여 그냥 문자열로 쿼리를 작성하였습니다.

그외에 출력된 CSV에 연락처가 숫자로 나오는 이슈를 수정했습니다.

## Related Issue
https://app.asana.com/0/235684600038401/460797858986117/f
