### PR TITLE
Refactor menus

### DIFF
--- a/src/Intra/Service/Menu/MenuService.php
+++ b/src/Intra/Service/Menu/MenuService.php
@@ -23,86 +23,106 @@ class MenuService
         $right_menu_list = [];
 
         if (UserSession::isLogined()) {
-            if ($_ENV['INTRA_DOMAIN'] == 'ridi.com') {
-                $left_menu_list = [
-                    new Link('직원찾기', '/users/', new ExceptStudioD()),
-                    new Link('RIDI PUBLIC', self::RIDI_GUIDE_URL, null, '_blank'),
-                    new Link('전사 주간 업무 요약', '/weekly/', new ExceptOuter(), '_blank'),
-                    new Link('회의실', '/rooms/', new ExceptTaAuth()),
-                    new LinkList('업무용 서비스', [
-                        new Link('아사나 (업무협업)', 'https://app.asana.com', null, '_blank'),
-                        new Link('Confluence (위키)', 'https://ridicorp.atlassian.net', null, '_blank'),
-                        new Link('모두싸인 (전자계약)', 'https://modusign.co.kr', null, '_blank'),
-                        new Link('비즈플레이 (개인영수관리)', 'https://www.bizplay.co.kr', null, '_blank'),
-                        new Link('월급날 (급여관리)', 'http://htms.himgt.net', new ExceptOuter(), '_blank'),
-                    ]),
-                    new LinkList('근태관리', [
-                        new Link('휴가신청', '/holidays/', new ExceptStudioD()),
-                        new Link('얼리파마', '/flextime/', new ExceptOuter()),
-                    ]),
-                    new LinkList('지원요청', [
-                        new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_DEVICE), '/support/' . SupportPolicy::TYPE_DEVICE, new ExceptStudioD(), '_blank'),
-                        new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_FAMILY_EVENT), '/support/' . SupportPolicy::TYPE_FAMILY_EVENT, new ExceptOuter()),
-                        new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_BUSINESS_CARD), '/support/' . SupportPolicy::TYPE_BUSINESS_CARD, new ExceptOuter()),
-                        new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_DEPOT), '/support/' . SupportPolicy::TYPE_DEPOT, (new ExceptOuter())->accept(['hr.ta'])),
-                        new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_GIFT_CARD_PURCHASE), '/support/' . SupportPolicy::TYPE_GIFT_CARD_PURCHASE),
-                        new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_TRAINING), '/support/' . SupportPolicy::TYPE_TRAINING, new ExceptOuter()),
-                        new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_DELIVERY), '/support/' . SupportPolicy::TYPE_DELIVERY, new ExceptOuter(), '_blank'),
-                        new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_PRESENT), '/support/' . SupportPolicy::TYPE_PRESENT, new ExceptOuter(), '_blank'),
-                        new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_VPN), '/support/' . SupportPolicy::TYPE_VPN, new ExceptOuter()),
-                        new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_BUSSINESSTRIP), '/support/' . SupportPolicy::TYPE_BUSSINESSTRIP, new ExceptOuter(), '_blank'),
-                    ]),
-                    new Link('결제요청', '/payments/', (new ExceptTaAuth())->accept(['hr.ta', 'device.ta3', 'story.op2'])),
-                    new Link('비용정산', '/receipts/', new ExceptOuter()),
-                    new Link('조직도', '/organization/chart', new ExceptOuter(), '_blank'),
-                ];
-            } else {
-                $left_menu_list = [
-                    new Link('공지사항', '/posts/notice', new PublicAuth()),
-                    new Link('휴가신청', '/holidays/', new PublicAuth()),
-                    new LinkList('지원요청', [
-                        new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_DEVICE), '/support/' . SupportPolicy::TYPE_DEVICE, new PublicAuth()),
-                        new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_FAMILY_EVENT), '/support/' . SupportPolicy::TYPE_FAMILY_EVENT),
-                        new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_BUSINESS_CARD), '/support/' . SupportPolicy::TYPE_BUSINESS_CARD),
-                        new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_DEPOT), '/support/' . SupportPolicy::TYPE_DEPOT, (new ExceptTaAuth())->accept(['hr.ta'])),
-                        new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_GIFT_CARD_PURCHASE), '/support/' . SupportPolicy::TYPE_GIFT_CARD_PURCHASE),
-                        new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_TRAINING), '/support/' . SupportPolicy::TYPE_TRAINING),
-                        new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_DELIVERY), '/support/' . SupportPolicy::TYPE_DELIVERY, new PublicAuth(), '_blank'),
-                        new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_PRESENT), '/support/' . SupportPolicy::TYPE_PRESENT, new PublicAuth(), '_blank'),
-                        new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_VPN), '/support/' . SupportPolicy::TYPE_VPN, new PublicAuth(), '_blank'),
-                    ]),
-                    new Link('비용정산', '/receipts/', new PublicAuth()),
-                    new Link('회의실', '/rooms/', new PublicAuth()),
-                    new LinkList('업무용 서비스', [
-                        new Link('아사나 (업무협업)', 'https://app.asana.com', null, '_blank'),
-                        new Link('Confluence (위키)', 'https://ridicorp.atlassian.net', null, '_blank'),
-                        new Link('모두싸인 (전자계약)', 'https://modusign.co.kr', null, '_blank'),
-                        new Link('비즈플레이 (개인영수관리)', 'https://www.bizplay.co.kr', null, '_blank'),
-                        new Link('월급날(급여관리)', 'http://htms.himgt.net', new ExceptOuter(), '_blank'),
-                    ]),
-                    new Link('리디 생활 가이드', self::RIDI_GUIDE_URL, null, '_blank'),
-                    new Link('급여관리', 'http://htms.himgt.net', new ExceptTaAuth(), '_blank'),
-                ];
-            }
-
-            $right_menu_list = [
-                new LinkList('관리자', [
-                    new Link('권한 설정', '/admin/policy', new OnlyPolicyRecipientEditable()),
-                    new Link('메일 수신 설정', '/admin/recipient', new OnlyPolicyRecipientEditable()),
-                    new Link('직원 목록', '/users/list', new OnlyUserManager()),
-                    new Link('휴가 조정', '/holidayadmin/', new OnlyHolidayEditable()),
-                    new Link('회의실 설정', '/admin/room', new OnlyPolicyRecipientEditable()),
-                    new Link('회의실 정기 예약', '/admin/event_group', new OnlyPolicyRecipientEditable()),
-                    new Link('보도자료 관리', '/press/', new OnlyPressManager()),
-                ], 'wrench'),
-                new Link('내정보', '/users/myinfo', new PublicAuth(), null, 'user'),
-                new Link('로그아웃', '/usersession/logout', new PublicAuth(), null, 'log-out'),
-            ];
+            $left_menu_list = self::createLeftMenus();
+            $right_menu_list = self::createRightMenus();
         }
 
         return [
             'left' => $left_menu_list,
             'right' => $right_menu_list
         ];
+    }
+
+    private static function createLeftMenus()
+    {
+        if ($_ENV['INTRA_DOMAIN'] == 'studiod.co.kr') {
+            return self::createStudiodMenus();
+        }
+
+        return self::createRidiMenus();
+    }
+
+    private static function createRidiMenus()
+    {
+        return [
+            new Link('직원찾기', '/users/', new ExceptStudioD()),
+            new Link('RIDI PUBLIC', self::RIDI_GUIDE_URL, null, '_blank'),
+            new Link('전사 주간 업무 요약', '/weekly/', new ExceptOuter(), '_blank'),
+            new Link('회의실', '/rooms/', new ExceptTaAuth()),
+            new LinkList('업무용 서비스', [
+                new Link('아사나 (업무협업)', 'https://app.asana.com', null, '_blank'),
+                new Link('Confluence (위키)', 'https://ridicorp.atlassian.net', null, '_blank'),
+                new Link('모두싸인 (전자계약)', 'https://modusign.co.kr', null, '_blank'),
+                new Link('비즈플레이 (개인영수관리)', 'https://www.bizplay.co.kr', null, '_blank'),
+                new Link('월급날 (급여관리)', 'http://htms.himgt.net', new ExceptOuter(), '_blank'),
+            ]),
+            new LinkList('근태관리', [
+                new Link('휴가신청', '/holidays/', new ExceptStudioD()),
+                new Link('얼리파마', '/flextime/', new ExceptOuter()),
+            ]),
+            new LinkList('지원요청', [
+                new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_DEVICE), '/support/' . SupportPolicy::TYPE_DEVICE, new ExceptStudioD(), '_blank'),
+                new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_FAMILY_EVENT), '/support/' . SupportPolicy::TYPE_FAMILY_EVENT, new ExceptOuter()),
+                new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_BUSINESS_CARD), '/support/' . SupportPolicy::TYPE_BUSINESS_CARD, new ExceptOuter()),
+                new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_DEPOT), '/support/' . SupportPolicy::TYPE_DEPOT, (new ExceptOuter())->accept(['hr.ta'])),
+                new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_GIFT_CARD_PURCHASE), '/support/' . SupportPolicy::TYPE_GIFT_CARD_PURCHASE),
+                new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_TRAINING), '/support/' . SupportPolicy::TYPE_TRAINING, new ExceptOuter()),
+                new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_DELIVERY), '/support/' . SupportPolicy::TYPE_DELIVERY, new ExceptOuter(), '_blank'),
+                new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_PRESENT), '/support/' . SupportPolicy::TYPE_PRESENT, new ExceptOuter(), '_blank'),
+                new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_VPN), '/support/' . SupportPolicy::TYPE_VPN, new ExceptOuter()),
+                new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_BUSSINESSTRIP), '/support/' . SupportPolicy::TYPE_BUSSINESSTRIP, new ExceptOuter(), '_blank'),
+            ]),
+            new Link('결제요청', '/payments/', (new ExceptTaAuth())->accept(['hr.ta', 'device.ta3', 'story.op2'])),
+            new Link('비용정산', '/receipts/', new ExceptOuter()),
+            new Link('조직도', '/organization/chart', new ExceptOuter(), '_blank'),
+        ];
+    }
+
+    private static function createStudiodMenus()
+    {
+        return [
+            new Link('공지사항', '/posts/notice', new PublicAuth()),
+            new Link('휴가신청', '/holidays/', new PublicAuth()),
+            new LinkList('지원요청', [
+                new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_DEVICE), '/support/' . SupportPolicy::TYPE_DEVICE, new PublicAuth()),
+                new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_FAMILY_EVENT), '/support/' . SupportPolicy::TYPE_FAMILY_EVENT),
+                new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_BUSINESS_CARD), '/support/' . SupportPolicy::TYPE_BUSINESS_CARD),
+                new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_DEPOT), '/support/' . SupportPolicy::TYPE_DEPOT, (new ExceptTaAuth())->accept(['hr.ta'])),
+                new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_GIFT_CARD_PURCHASE), '/support/' . SupportPolicy::TYPE_GIFT_CARD_PURCHASE),
+                new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_TRAINING), '/support/' . SupportPolicy::TYPE_TRAINING),
+                new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_DELIVERY), '/support/' . SupportPolicy::TYPE_DELIVERY, new PublicAuth(), '_blank'),
+                new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_PRESENT), '/support/' . SupportPolicy::TYPE_PRESENT, new PublicAuth(), '_blank'),
+                new Link(SupportPolicy::getColumnTitle(SupportPolicy::TYPE_VPN), '/support/' . SupportPolicy::TYPE_VPN, new PublicAuth(), '_blank'),
+            ]),
+            new Link('비용정산', '/receipts/', new PublicAuth()),
+            new Link('회의실', '/rooms/', new PublicAuth()),
+            new LinkList('업무용 서비스', [
+                new Link('아사나 (업무협업)', 'https://app.asana.com', null, '_blank'),
+                new Link('Confluence (위키)', 'https://ridicorp.atlassian.net', null, '_blank'),
+                new Link('모두싸인 (전자계약)', 'https://modusign.co.kr', null, '_blank'),
+                new Link('비즈플레이 (개인영수관리)', 'https://www.bizplay.co.kr', null, '_blank'),
+                new Link('월급날(급여관리)', 'http://htms.himgt.net', new ExceptOuter(), '_blank'),
+            ]),
+            new Link('리디 생활 가이드', self::RIDI_GUIDE_URL, null, '_blank'),
+            new Link('급여관리', 'http://htms.himgt.net', new ExceptTaAuth(), '_blank'),
+        ];
+    }
+
+    private static function createRightMenus()
+    {
+        return [
+            new LinkList('관리자', [
+                new Link('권한 설정', '/admin/policy', new OnlyPolicyRecipientEditable()),
+                new Link('메일 수신 설정', '/admin/recipient', new OnlyPolicyRecipientEditable()),
+                new Link('직원 목록', '/users/list', new OnlyUserManager()),
+                new Link('휴가 조정', '/holidayadmin/', new OnlyHolidayEditable()),
+                new Link('회의실 설정', '/admin/room', new OnlyPolicyRecipientEditable()),
+                new Link('회의실 정기 예약', '/admin/event_group', new OnlyPolicyRecipientEditable()),
+                new Link('보도자료 관리', '/press/', new OnlyPressManager()),
+            ], 'wrench'),
+            new Link('내정보', '/users/myinfo', new PublicAuth(), null, 'user'),
+            new Link('로그아웃', '/usersession/logout', new PublicAuth(), null, 'log-out'),
+        ];
+
     }
 }


### PR DESCRIPTION
ridicorp.com 도메인을 적용하려고보니 ridi.com이 하드코딩되어 있어 변경해야했는데요, 
ridicorp.com을 하드코딩하기보다는 ridi 메뉴를 기본 메뉴로 리턴하게끔하고 studiod.co.kr을 예외처리의 개념으로 구성하게 수정했습니다.